### PR TITLE
Add methods intended for managing pupils and guardians

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
           name: "JwtApiClient",
-          url: "git@github.com:chris-kobrzak/JsonApiClient.git", .upToNextMinor(from: "4.0.0")
+          url: "git@github.com:chris-kobrzak/JsonApiClient.git", .upToNextMinor(from: "4.1.0")
         ),
         .package(
           name: "Mockingbird",

--- a/Sources/ChildrensVillageApiClient/Builders/buildParentRequestFilter.swift
+++ b/Sources/ChildrensVillageApiClient/Builders/buildParentRequestFilter.swift
@@ -1,0 +1,23 @@
+//
+//  buildParentRequestFilter.swift
+//  ChildrensVillageApiClient
+//
+//  Created by Chris Kobrzak on 19/11/2025.
+//
+
+import Foundation
+
+func buildParentRequestFilter() -> ParentRequestFilter {
+  return GRF(
+    fields: GRF.Field(
+      id: true,
+      active: true,
+      facilitating: true,
+      prefix: true,
+      firstName: true,
+      lastName: true,
+      phone: true,
+      email: true
+    )
+  )
+}

--- a/Sources/ChildrensVillageApiClient/Builders/buildParentSummariesRequestFilter.swift
+++ b/Sources/ChildrensVillageApiClient/Builders/buildParentSummariesRequestFilter.swift
@@ -1,0 +1,24 @@
+//
+//  buildParentSummariesRequestFilter.swift
+//  Builds a tree of nested structures representing the URL
+//  filter for the parent summaries API request query string.
+//
+//  Created on 25/06/2025.
+//
+
+import Foundation
+
+func buildParentSummariesRequestFilter() -> ParentSummariesRequestFilter {
+  return ASRF(
+    fields: ASRF.Field(
+      id: true,
+      active: true,
+      facilitating: true,
+      firstName: true,
+      lastName: true,
+      prefix: true
+    ),
+    order: "lastName, firstName",
+    limit: 1000
+  )
+}

--- a/Sources/ChildrensVillageApiClient/Builders/buildPupilSummariesRequestFilter.swift
+++ b/Sources/ChildrensVillageApiClient/Builders/buildPupilSummariesRequestFilter.swift
@@ -1,0 +1,23 @@
+//
+//  buildPupilSummariesRequestFilter.swift
+//  Builds a tree of nested structures representing the URL
+//  filter for the pupils API request query string.
+//
+//  Created by Claude Sonnet based on the TypeScript equivalent on 25/06/2025.
+//
+
+import Foundation
+
+func buildPupilSummariesRequestFilter() -> PupilSummariesRequestFilter {
+  return PSRF(
+    fields: PSRF.Field(
+      id: true,
+      active: true,
+      firstName: true,
+      lastName: true,
+      dateOfBirth: false,
+      prefix: true
+    ),
+    order: "firstName"
+  )
+}

--- a/Sources/ChildrensVillageApiClient/Builders/buildPupilSummariesRequestFilter.swift
+++ b/Sources/ChildrensVillageApiClient/Builders/buildPupilSummariesRequestFilter.swift
@@ -18,6 +18,7 @@ func buildPupilSummariesRequestFilter() -> PupilSummariesRequestFilter {
       dateOfBirth: false,
       prefix: true
     ),
-    order: "firstName"
+    order: "firstName",
+    limit: 1000
   )
 }

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -55,7 +55,7 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     _ token: String,
     _ parentId: UUID,
     _ parent: UpdateParentRequestModel
-  ) async throws -> Int {
+  ) async throws {
     try await updateParentTask(apiClient: apiClient, token, parentId, parent)
   }
 

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -32,7 +32,7 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
   public func createPupil(
     _ token: String,
     _ pupil: NewPupilRequestModel
-  ) async throws -> PupilModel {
+  ) async throws -> UUID {
     return try await createPupilTask(apiClient: apiClient, token, pupil)
   }
 

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -39,7 +39,7 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
   public func createParent(
     _ token: String,
     _ parent: NewParentRequestModel
-  ) async throws -> ParentModel {
+  ) async throws -> UUID {
     try await createParentTask(apiClient: apiClient, token, parent)
   }
 

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -43,6 +43,14 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     try await createParentTask(apiClient: apiClient, token, parent)
   }
 
+  public func updatePupil(
+    _ token: String,
+    _ pupilId: UUID,
+    _ pupil: UpdatePupilRequestModel
+  ) async throws -> Int {
+    try await updatePupilTask(apiClient: apiClient, token, pupilId, pupil)
+  }
+
   public func updateParent(
     _ token: String,
     _ parentId: UUID,

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -31,18 +31,15 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
 
   public func createPupilWithAssociations(
     _ token: String,
-    _ pupil: NewPupilRequestModel,
-    _ parentIds: [UUID],
-    _ branchIds: [Int],
-    _ dayIds: [Int]
+    _ pupilRequest: NewPupilWithAssociationsRequestModel
   ) async throws -> UUID {
     try await createPupilWithAssociationsTask(
       apiClient: apiClient,
       token,
-      pupil,
-      parentIds,
-      branchIds,
-      dayIds
+      pupilRequest.pupilData,
+      pupilRequest.parentIds,
+      pupilRequest.branchIds,
+      pupilRequest.dayIds
     )
   }
 
@@ -63,19 +60,16 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
   public func updatePupilWithAssociations(
     _ token: String,
     _ pupilId: UUID,
-    _ pupil: UpdatePupilRequestModel,
-    _ parentIds: [UUID],
-    _ branchIds: [Int],
-    _ dayIds: [Int]
+    _ pupilRequest: UpdatePupilWithAssociationsRequestModel
   ) async throws {
     try await updatePupilWithAssociationsTask(
       apiClient: apiClient,
       token,
       pupilId,
-      pupil,
-      parentIds,
-      branchIds,
-      dayIds
+      pupilRequest.pupilData,
+      pupilRequest.parentIds ?? [],
+      pupilRequest.branchIds ?? [],
+      pupilRequest.dayIds ?? []
     )
   }
 

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -29,6 +29,23 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     return try await updatePasswordTask(apiClient: apiClient, verificationToken, password)
   }
 
+  public func createPupilWithAssociations(
+    _ token: String,
+    _ pupil: NewPupilRequestModel,
+    _ parentIds: [UUID],
+    _ branchIds: [Int],
+    _ dayIds: [Int]
+  ) async throws -> UUID {
+    try await createPupilWithAssociationsTask(
+      apiClient: apiClient,
+      token,
+      pupil,
+      parentIds,
+      branchIds,
+      dayIds
+    )
+  }
+
   public func createPupil(
     _ token: String,
     _ pupil: NewPupilRequestModel

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -37,6 +37,10 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     try await requestPupilSummariesTask(apiClient: apiClient, token)
   }
 
+  public func requestParentSummaries(_ token: String) async throws -> [ParentModel] {
+    try await requestParentSummariesTask(apiClient: apiClient, token)
+  }
+
   public func requestPupilsRegister(
     _ token: String,
     _ branchId: Int,

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -43,6 +43,14 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     try await createParentTask(apiClient: apiClient, token, parent)
   }
 
+  public func updateParent(
+    _ token: String,
+    _ parentId: UUID,
+    _ parent: UpdateParentRequestModel
+  ) async throws -> Int {
+    try await updateParentTask(apiClient: apiClient, token, parentId, parent)
+  }
+
   public func requestPupil(_ token: String, _ pupilId: UUID) async throws -> PupilModel {
     try await requestPupilTask(apiClient: apiClient, token, pupilId)
   }

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -43,6 +43,25 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     try await createParentTask(apiClient: apiClient, token, parent)
   }
 
+  public func updatePupilWithAssociations(
+    _ token: String,
+    _ pupilId: UUID,
+    _ pupil: UpdatePupilRequestModel,
+    _ parentIds: [UUID],
+    _ branchIds: [Int],
+    _ dayIds: [Int]
+  ) async throws {
+    try await updatePupilWithAssociationsTask(
+      apiClient: apiClient,
+      token,
+      pupilId,
+      pupil,
+      parentIds,
+      branchIds,
+      dayIds
+    )
+  }
+
   public func updatePupil(
     _ token: String,
     _ pupilId: UUID,
@@ -128,5 +147,29 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     _ date: Date?
   ) async throws {
     try await clockOffPupilTask(apiClient: apiClient, token, attendanceId, date)
+  }
+
+  public func updatePupilParents(
+    _ token: String,
+    _ pupilId: UUID,
+    _ parentIds: [UUID]
+  ) async throws {
+    try await updatePupilParentsTask(apiClient: apiClient, token, pupilId, parentIds)
+  }
+
+  public func updatePupilBranches(
+    _ token: String,
+    _ pupilId: UUID,
+    _ branchIds: [Int]
+  ) async throws {
+    try await updatePupilBranchesTask(apiClient: apiClient, token, pupilId, branchIds)
+  }
+
+  public func updatePupilDaysOfWeek(
+    _ token: String,
+    _ pupilId: UUID,
+    _ dayIds: [Int]
+  ) async throws {
+    try await updatePupilDaysOfWeekTask(apiClient: apiClient, token, pupilId, dayIds)
   }
 }

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -99,6 +99,10 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     try await requestPupilTask(apiClient: apiClient, token, pupilId)
   }
 
+  public func requestParent(_ token: String, _ parentId: UUID) async throws -> ParentModel {
+    try await requestParentTask(apiClient: apiClient, token, parentId)
+  }
+
   public func requestPupilSummaries(_ token: String) async throws -> [PupilModel] {
     try await requestPupilSummariesTask(apiClient: apiClient, token)
   }

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -29,6 +29,13 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     return try await updatePasswordTask(apiClient: apiClient, verificationToken, password)
   }
 
+  public func createPupil(
+    _ token: String,
+    _ pupil: NewPupilRequestModel
+  ) async throws -> PupilModel {
+    return try await createPupilTask(apiClient: apiClient, token, pupil)
+  }
+
   public func requestPupil(_ token: String, _ pupilId: UUID) async throws -> PupilModel {
     try await requestPupilTask(apiClient: apiClient, token, pupilId)
   }

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -36,6 +36,13 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     return try await createPupilTask(apiClient: apiClient, token, pupil)
   }
 
+  public func createParent(
+    _ token: String,
+    _ parent: NewParentRequestModel
+  ) async throws -> ParentModel {
+    try await createParentTask(apiClient: apiClient, token, parent)
+  }
+
   public func requestPupil(_ token: String, _ pupilId: UUID) async throws -> PupilModel {
     try await requestPupilTask(apiClient: apiClient, token, pupilId)
   }

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -47,7 +47,7 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     _ token: String,
     _ pupilId: UUID,
     _ pupil: UpdatePupilRequestModel
-  ) async throws -> Int {
+  ) async throws {
     try await updatePupilTask(apiClient: apiClient, token, pupilId, pupil)
   }
 

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiClient.swift
@@ -33,6 +33,10 @@ public struct ChildrensVillageApiClient: ChildrensVillageApiCompatible {
     try await requestPupilTask(apiClient: apiClient, token, pupilId)
   }
 
+  public func requestPupilSummaries(_ token: String) async throws -> [PupilModel] {
+    try await requestPupilSummariesTask(apiClient: apiClient, token)
+  }
+
   public func requestPupilsRegister(
     _ token: String,
     _ branchId: Int,

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -33,12 +33,11 @@ public protocol ChildrensVillageApiCompatible: Sendable {
     _ pupil: UpdatePupilRequestModel
   ) async throws
 
-  // Returns HTTP status code
   func updateParent(
     _ token: String,
     _ parentId: UUID,
     _ parent: UpdateParentRequestModel
-  ) async throws -> Int
+  ) async throws
 
   func requestPupil(
     _ token: String,

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -24,10 +24,7 @@ public protocol ChildrensVillageApiCompatible: Sendable {
   // Returns created pupil UUID
   func createPupilWithAssociations(
     _ token: String,
-    _ pupil: NewPupilRequestModel,
-    _ parentIds: [UUID],
-    _ branchIds: [Int],
-    _ dayIds: [Int]
+    _ pupilRequest: NewPupilWithAssociationsRequestModel
   ) async throws -> UUID
 
   func createPupil(
@@ -38,10 +35,7 @@ public protocol ChildrensVillageApiCompatible: Sendable {
   func updatePupilWithAssociations(
     _ token: String,
     _ pupilId: UUID,
-    _ pupil: UpdatePupilRequestModel,
-    _ parentIds: [UUID],
-    _ branchIds: [Int],
-    _ dayIds: [Int]
+    _ pupilRequest: UpdatePupilWithAssociationsRequestModel
   ) async throws
 
   func updatePupil(

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -28,6 +28,13 @@ public protocol ChildrensVillageApiCompatible: Sendable {
   ) async throws -> UUID
 
   // Returns HTTP status code
+  func updatePupil(
+    _ token: String,
+    _ pupilId: UUID,
+    _ pupil: UpdatePupilRequestModel
+  ) async throws -> Int
+
+  // Returns HTTP status code
   func updateParent(
     _ token: String,
     _ parentId: UUID,

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -15,10 +15,11 @@ public protocol ChildrensVillageApiCompatible: Sendable {
   // Returns HTTP status code
   func updatePassword(_ verificationToken: String, _ password: String) async throws -> Int
 
+  // Returns created parent UUID
   func createParent(
     _ token: String,
     _ parent: NewParentRequestModel
-  ) async throws -> ParentModel
+  ) async throws -> UUID
 
   // Returns HTTP status code
   func updateParent(

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -24,6 +24,10 @@ public protocol ChildrensVillageApiCompatible: Sendable {
     _ token: String
   ) async throws -> [PupilModel]
 
+  func requestParentSummaries(
+    _ token: String
+  ) async throws -> [ParentModel]
+
   func requestPupilsRegister(
     _ token: String,
     _ branchId: Int,

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -20,6 +20,10 @@ public protocol ChildrensVillageApiCompatible: Sendable {
     _ pupilId: UUID
   ) async throws -> PupilModel
 
+  func requestPupilSummaries(
+    _ token: String
+  ) async throws -> [PupilModel]
+
   func requestPupilsRegister(
     _ token: String,
     _ branchId: Int,

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -27,6 +27,15 @@ public protocol ChildrensVillageApiCompatible: Sendable {
     _ pupil: NewPupilRequestModel
   ) async throws -> UUID
 
+  func updatePupilWithAssociations(
+    _ token: String,
+    _ pupilId: UUID,
+    _ pupil: UpdatePupilRequestModel,
+    _ parentIds: [UUID],
+    _ branchIds: [Int],
+    _ dayIds: [Int]
+  ) async throws
+
   func updatePupil(
     _ token: String,
     _ pupilId: UUID,
@@ -90,5 +99,23 @@ public protocol ChildrensVillageApiCompatible: Sendable {
     _ token: String,
     _ attendanceId: Int,
     _ date: Date?
+  ) async throws
+
+  func updatePupilParents(
+    _ token: String,
+    _ pupilId: UUID,
+    _ parentIds: [UUID]
+  ) async throws
+
+  func updatePupilBranches(
+    _ token: String,
+    _ pupilId: UUID,
+    _ branchIds: [Int]
+  ) async throws
+
+  func updatePupilDaysOfWeek(
+    _ token: String,
+    _ pupilId: UUID,
+    _ dayIds: [Int]
   ) async throws
 }

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -20,6 +20,13 @@ public protocol ChildrensVillageApiCompatible: Sendable {
     _ parent: NewParentRequestModel
   ) async throws -> ParentModel
 
+  // Returns HTTP status code
+  func updateParent(
+    _ token: String,
+    _ parentId: UUID,
+    _ parent: UpdateParentRequestModel
+  ) async throws -> Int
+
   func requestPupil(
     _ token: String,
     _ pupilId: UUID

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -21,6 +21,12 @@ public protocol ChildrensVillageApiCompatible: Sendable {
     _ parent: NewParentRequestModel
   ) async throws -> UUID
 
+  // Returns created pupil UUID
+  func createPupil(
+    _ token: String,
+    _ pupil: NewPupilRequestModel
+  ) async throws -> UUID
+
   // Returns HTTP status code
   func updateParent(
     _ token: String,

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -27,12 +27,11 @@ public protocol ChildrensVillageApiCompatible: Sendable {
     _ pupil: NewPupilRequestModel
   ) async throws -> UUID
 
-  // Returns HTTP status code
   func updatePupil(
     _ token: String,
     _ pupilId: UUID,
     _ pupil: UpdatePupilRequestModel
-  ) async throws -> Int
+  ) async throws
 
   // Returns HTTP status code
   func updateParent(

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -22,6 +22,14 @@ public protocol ChildrensVillageApiCompatible: Sendable {
   ) async throws -> UUID
 
   // Returns created pupil UUID
+  func createPupilWithAssociations(
+    _ token: String,
+    _ pupil: NewPupilRequestModel,
+    _ parentIds: [UUID],
+    _ branchIds: [Int],
+    _ dayIds: [Int]
+  ) async throws -> UUID
+
   func createPupil(
     _ token: String,
     _ pupil: NewPupilRequestModel

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -61,6 +61,11 @@ public protocol ChildrensVillageApiCompatible: Sendable {
     _ pupilId: UUID
   ) async throws -> PupilModel
 
+  func requestParent(
+    _ token: String,
+    _ parentId: UUID
+  ) async throws -> ParentModel
+
   func requestPupilSummaries(
     _ token: String
   ) async throws -> [PupilModel]

--- a/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
+++ b/Sources/ChildrensVillageApiClient/ChildrensVillageApiCompatible.swift
@@ -15,6 +15,11 @@ public protocol ChildrensVillageApiCompatible: Sendable {
   // Returns HTTP status code
   func updatePassword(_ verificationToken: String, _ password: String) async throws -> Int
 
+  func createParent(
+    _ token: String,
+    _ parent: NewParentRequestModel
+  ) async throws -> ParentModel
+
   func requestPupil(
     _ token: String,
     _ pupilId: UUID

--- a/Sources/ChildrensVillageApiClient/DateUtilities/DayOfWeek.swift
+++ b/Sources/ChildrensVillageApiClient/DateUtilities/DayOfWeek.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum DayOfWeek: String, CaseIterable, Codable, Equatable {
+public enum DayOfWeek: String, CaseIterable, Codable, Equatable, Sendable {
   case Monday
   case Tuesday
   case Wednesday

--- a/Sources/ChildrensVillageApiClient/FilterModels/ParentRequestFilter.swift
+++ b/Sources/ChildrensVillageApiClient/FilterModels/ParentRequestFilter.swift
@@ -1,0 +1,30 @@
+//
+//  ParentRequestFilter.swift
+//  ChildrensVillageApiClient
+//
+//  Created by Chris Kobrzak on 19/11/2025.
+//
+
+// G stands for Guardian (PRF already taken)
+typealias GRF = ParentRequestFilter
+
+struct ParentRequestFilter: Encodable, Equatable {
+  var fields: Field?
+  var `where`: Where?
+
+  struct Field: Encodable, Equatable {
+    var id: Bool
+    var active: Bool
+    var facilitating: Bool
+    var prefix: Bool
+    var firstName: Bool
+    var lastName: Bool
+    var phone: Bool
+    var email: Bool
+  }
+
+  struct Where: Encodable, Equatable {
+    var active: Bool?
+    var id: PredicateInUuid?
+  }
+}

--- a/Sources/ChildrensVillageApiClient/FilterModels/ParentSummariesRequestFilter.swift
+++ b/Sources/ChildrensVillageApiClient/FilterModels/ParentSummariesRequestFilter.swift
@@ -1,0 +1,24 @@
+//
+//  ParentSummariesRequestFilter.swift
+//  ChildrensVillageApiClient
+//
+//  Created by Chris Kobrzak on 25/06/2025.
+//
+
+
+typealias ASRF = ParentSummariesRequestFilter
+
+struct ParentSummariesRequestFilter: Codable {
+  let fields: Field
+  let order: String
+  let limit: Int
+
+  struct Field: Codable {
+    let id: Bool
+    let active: Bool
+    let facilitating: Bool
+    let firstName: Bool
+    let lastName: Bool
+    let prefix: Bool
+  }
+}

--- a/Sources/ChildrensVillageApiClient/FilterModels/PupilSummariesRequestFilter.swift
+++ b/Sources/ChildrensVillageApiClient/FilterModels/PupilSummariesRequestFilter.swift
@@ -1,0 +1,24 @@
+//
+//  PupilsRequestFilter.swift
+//  
+//
+//  Created on 25/06/2025.
+//
+
+import Foundation
+
+typealias PSRF = PupilSummariesRequestFilter
+
+struct PupilSummariesRequestFilter: Encodable {
+  let fields: Field
+  let order: String
+  
+  struct Field: Encodable {
+    let id: Bool
+    let active: Bool
+    let firstName: Bool
+    let lastName: Bool
+    let dateOfBirth: Bool
+    let prefix: Bool
+  }
+}

--- a/Sources/ChildrensVillageApiClient/FilterModels/PupilSummariesRequestFilter.swift
+++ b/Sources/ChildrensVillageApiClient/FilterModels/PupilSummariesRequestFilter.swift
@@ -12,7 +12,8 @@ typealias PSRF = PupilSummariesRequestFilter
 struct PupilSummariesRequestFilter: Encodable {
   let fields: Field
   let order: String
-  
+  let limit: Int
+
   struct Field: Encodable {
     let id: Bool
     let active: Bool

--- a/Sources/ChildrensVillageApiClient/RequestModels/NewParentRequestModel.swift
+++ b/Sources/ChildrensVillageApiClient/RequestModels/NewParentRequestModel.swift
@@ -1,0 +1,41 @@
+//
+//  NewParentRequestModel.swift
+//  ChildrensVillageApiClient
+//
+//  Created on 19/11/2025.
+//
+
+import Foundation
+
+public struct NewParentRequestModel: Codable, Equatable, Sendable {
+  public let prefix: TitlePrefix
+  public let firstName: String
+  public let lastName: String
+  public let active: Bool
+  public let facilitating: Bool
+  public let phone: String
+  public let email: String
+
+  @available(*, deprecated, message: "This property is no longer used")
+  public let primary: Bool?
+
+  public init(
+    prefix: TitlePrefix,
+    firstName: String,
+    lastName: String,
+    active: Bool,
+    facilitating: Bool,
+    phone: String,
+    email: String,
+    primary: Bool? = nil
+  ) {
+    self.prefix = prefix
+    self.firstName = firstName
+    self.lastName = lastName
+    self.active = active
+    self.facilitating = facilitating
+    self.phone = phone
+    self.email = email
+    self.primary = primary
+  }
+}

--- a/Sources/ChildrensVillageApiClient/RequestModels/NewPupilRequestModel.swift
+++ b/Sources/ChildrensVillageApiClient/RequestModels/NewPupilRequestModel.swift
@@ -1,0 +1,39 @@
+//
+//  NewPupilRequestModel.swift
+//  ChildrensVillageApiClient
+//
+//  Created by Chris Kobrzak on 25/06/2025.
+//
+import Foundation
+
+// TODO: Could this type be merged with UpdatePupilRequestModel?
+public struct NewPupilRequestModel: Codable, Equatable, Sendable {
+  public let prefix: TitlePrefix
+  public let firstName: String
+  public let lastName: String
+  public let dateOfBirth: String?
+  public let active: Bool
+  public let activeUntil: String?
+  public let photographyConsent: Bool
+  public let allergies: String?
+
+  public init(
+    prefix: TitlePrefix,
+    firstName: String,
+    lastName: String,
+    dateOfBirth: String? = nil,
+    active: Bool = false,
+    activeUntil: String? = nil,
+    photographyConsent: Bool = false,
+    allergies: String? = nil
+  ) {
+    self.prefix = prefix
+    self.firstName = firstName
+    self.lastName = lastName
+    self.dateOfBirth = dateOfBirth
+    self.active = active
+    self.activeUntil = activeUntil
+    self.photographyConsent = photographyConsent
+    self.allergies = allergies
+  }
+}

--- a/Sources/ChildrensVillageApiClient/RequestModels/NewPupilWithAssociationsRequestModel.swift
+++ b/Sources/ChildrensVillageApiClient/RequestModels/NewPupilWithAssociationsRequestModel.swift
@@ -1,0 +1,66 @@
+//
+//  NewPupilWithAssociationsRequestModel.swift
+//  ChildrensVillageApiClient
+//
+//  Created on 19/11/2025.
+//
+
+import Foundation
+
+/// A comprehensive request model for creating a new pupil with all associated data
+public struct NewPupilWithAssociationsRequestModel: Codable, Equatable, Sendable {
+  // Core pupil data
+  public let prefix: TitlePrefix
+  public let firstName: String
+  public let lastName: String
+  public let dateOfBirth: String?
+  public let active: Bool
+  public let activeUntil: String?
+  public let photographyConsent: Bool
+  public let allergies: String?
+
+  // Associations
+  public let parentIds: [UUID]
+  public let branchIds: [Int]
+  public let dayIds: [Int]
+
+  public init(
+    prefix: TitlePrefix,
+    firstName: String,
+    lastName: String,
+    dateOfBirth: String? = nil,
+    active: Bool = false,
+    activeUntil: String? = nil,
+    photographyConsent: Bool = false,
+    allergies: String? = nil,
+    parentIds: [UUID] = [],
+    branchIds: [Int] = [],
+    dayIds: [Int] = []
+  ) {
+    self.prefix = prefix
+    self.firstName = firstName
+    self.lastName = lastName
+    self.dateOfBirth = dateOfBirth
+    self.active = active
+    self.activeUntil = activeUntil
+    self.photographyConsent = photographyConsent
+    self.allergies = allergies
+    self.parentIds = parentIds
+    self.branchIds = branchIds
+    self.dayIds = dayIds
+  }
+
+  /// Convert to the basic NewPupilRequestModel (for internal API separation)
+  public var pupilData: NewPupilRequestModel {
+    NewPupilRequestModel(
+      prefix: prefix,
+      firstName: firstName,
+      lastName: lastName,
+      dateOfBirth: dateOfBirth,
+      active: active,
+      activeUntil: activeUntil,
+      photographyConsent: photographyConsent,
+      allergies: allergies
+    )
+  }
+}

--- a/Sources/ChildrensVillageApiClient/RequestModels/UpdateParentRequestModel.swift
+++ b/Sources/ChildrensVillageApiClient/RequestModels/UpdateParentRequestModel.swift
@@ -1,0 +1,36 @@
+//
+//  UpdateParentRequestModel.swift
+//  ChildrensVillageApiClient
+//
+//  Created on 2/11/2025.
+//
+
+import Foundation
+
+public struct UpdateParentRequestModel: Codable, Equatable {
+  public let prefix: TitlePrefix?
+  public let firstName: String?
+  public let lastName: String?
+  public let active: Bool?
+  public let facilitating: Bool?
+  public let phone: String?
+  public let email: String?
+
+  public init(
+    prefix: TitlePrefix? = nil,
+    firstName: String? = nil,
+    lastName: String? = nil,
+    active: Bool? = nil,
+    facilitating: Bool? = nil,
+    phone: String? = nil,
+    email: String? = nil
+  ) {
+    self.prefix = prefix
+    self.firstName = firstName
+    self.lastName = lastName
+    self.active = active
+    self.facilitating = facilitating
+    self.phone = phone
+    self.email = email
+  }
+}

--- a/Sources/ChildrensVillageApiClient/RequestModels/UpdatePupilRequestModel.swift
+++ b/Sources/ChildrensVillageApiClient/RequestModels/UpdatePupilRequestModel.swift
@@ -1,0 +1,39 @@
+//
+//  UpdatePupilRequestModel.swift
+//  ChildrensVillageApiClient
+//
+//  Created on 2/11/2025.
+//
+
+import Foundation
+
+public struct UpdatePupilRequestModel: Codable, Equatable, Sendable {
+  public let prefix: TitlePrefix?
+  public let firstName: String?
+  public let lastName: String?
+  public let dateOfBirth: String?
+  public let active: Bool?
+  public let activeUntil: String?
+  public let photographyConsent: Bool?
+  public let allergies: String?
+
+  public init(
+    prefix: TitlePrefix? = nil,
+    firstName: String? = nil,
+    lastName: String? = nil,
+    dateOfBirth: String? = nil,
+    active: Bool? = nil,
+    activeUntil: String? = nil,
+    photographyConsent: Bool? = nil,
+    allergies: String? = nil
+  ) {
+    self.prefix = prefix
+    self.firstName = firstName
+    self.lastName = lastName
+    self.dateOfBirth = dateOfBirth
+    self.active = active
+    self.activeUntil = activeUntil
+    self.photographyConsent = photographyConsent
+    self.allergies = allergies
+  }
+}

--- a/Sources/ChildrensVillageApiClient/RequestModels/UpdatePupilWithAssociationsRequestModel.swift
+++ b/Sources/ChildrensVillageApiClient/RequestModels/UpdatePupilWithAssociationsRequestModel.swift
@@ -1,0 +1,65 @@
+//
+//  UpdatePupilWithAssociationsRequestModel.swift
+//  ChildrensVillageApiClient
+//
+//  Created on 19/11/2025.
+//
+
+import Foundation
+
+public struct UpdatePupilWithAssociationsRequestModel: Codable, Equatable, Sendable {
+  // Core pupil data
+  public let prefix: TitlePrefix?
+  public let firstName: String?
+  public let lastName: String?
+  public let dateOfBirth: String?
+  public let active: Bool?
+  public let activeUntil: String?
+  public let photographyConsent: Bool?
+  public let allergies: String?
+
+  // Relations
+  public let parentIds: [UUID]?
+  public let branchIds: [Int]?
+  public let dayIds: [Int]?
+
+  public init(
+    prefix: TitlePrefix? = nil,
+    firstName: String? = nil,
+    lastName: String? = nil,
+    dateOfBirth: String? = nil,
+    active: Bool? = nil,
+    activeUntil: String? = nil,
+    photographyConsent: Bool? = nil,
+    allergies: String? = nil,
+    parentIds: [UUID]? = nil,
+    branchIds: [Int]? = nil,
+    dayIds: [Int]? = nil
+  ) {
+    self.prefix = prefix
+    self.firstName = firstName
+    self.lastName = lastName
+    self.dateOfBirth = dateOfBirth
+    self.active = active
+    self.activeUntil = activeUntil
+    self.photographyConsent = photographyConsent
+    self.allergies = allergies
+    self.parentIds = parentIds
+    self.branchIds = branchIds
+    self.dayIds = dayIds
+  }
+
+  /// Convert to the basic UpdatePupilRequestModel (for internal API separation)
+  public var pupilData: UpdatePupilRequestModel {
+    UpdatePupilRequestModel(
+      prefix: prefix,
+      firstName: firstName,
+      lastName: lastName,
+      dateOfBirth: dateOfBirth,
+      active: active,
+      activeUntil: activeUntil,
+      photographyConsent: photographyConsent,
+      allergies: allergies
+    )
+  }
+}

--- a/Sources/ChildrensVillageApiClient/Requests/createParentTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/createParentTask.swift
@@ -1,0 +1,36 @@
+//
+//  createParentTask.swift
+//
+//
+//  Created on 25/06/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func createParentTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ parent: NewParentRequestModel
+) async throws -> ParentModel {
+  let endpoint = buildParentsUrlComponent().url!
+
+  let body: [String: Any] = [
+    "active": parent.active,
+    "facilitating": parent.facilitating,
+    "primary": true,
+    "prefix": parent.prefix.rawValue,
+    "firstName": parent.firstName,
+    "lastName": parent.lastName,
+    "phone": parent.phone,
+    "email": parent.email
+  ]
+
+  return try await apiClient.post(url: endpoint, dictionary: body, token: token)
+}
+
+fileprivate func buildParentsUrlComponent() -> URLComponents {
+  let path = "/parents"
+
+  return buildUrlComponent(path)
+}

--- a/Sources/ChildrensVillageApiClient/Requests/createParentTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/createParentTask.swift
@@ -12,7 +12,7 @@ func createParentTask(
   apiClient: JsonApiCompatible = JsonApiClient(),
   _ token: String,
   _ parent: NewParentRequestModel
-) async throws -> ParentModel {
+) async throws -> UUID {
   let endpoint = buildParentsUrlComponent().url!
 
   let body: [String: Any] = [
@@ -26,7 +26,8 @@ func createParentTask(
     "email": parent.email
   ]
 
-  return try await apiClient.post(url: endpoint, dictionary: body, token: token)
+  let createdParent: ParentModel = try await apiClient.post(url: endpoint, dictionary: body, token: token)
+  return createdParent.id
 }
 
 fileprivate func buildParentsUrlComponent() -> URLComponents {

--- a/Sources/ChildrensVillageApiClient/Requests/createPupilBranchesTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/createPupilBranchesTask.swift
@@ -1,0 +1,34 @@
+//
+//  createPupilBranchesTask.swift
+//  ChildrensVillageApiClient
+//
+//  Created by Chris Kobrzak on 18/11/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func createPupilBranchesTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ pupilId: UUID,
+  _ branchIds: [Int]
+) async throws {
+  let endpoint = buildPupilBranchesUrlComponent(pupilId: pupilId).url!
+
+  for branchId in branchIds {
+    let body = ["id": branchId]
+
+    let _ = try await apiClient.post(
+      url: endpoint,
+      dictionary: body,
+      token: token
+    )
+  }
+}
+
+fileprivate func buildPupilBranchesUrlComponent(pupilId: UUID) -> URLComponents {
+  let path = "/pupils/\(pupilId)/branches"
+
+  return buildUrlComponent(path)
+}

--- a/Sources/ChildrensVillageApiClient/Requests/createPupilDaysOfWeekTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/createPupilDaysOfWeekTask.swift
@@ -1,0 +1,36 @@
+//
+//  createPupilDaysOfWeekTask.swift
+//  ChildrensVillageApiClient
+//
+//  Created by Chris Kobrzak on 18/11/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func createPupilDaysOfWeekTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ pupilId: UUID,
+  _ dayIds: [Int]
+) async throws {
+  let endpoint = buildPupilDaysOfWeekUrlComponent(pupilId: pupilId).url!
+
+  for dayId in dayIds {
+    let body: [String: Int] = [
+      "id": dayId
+    ]
+
+    let _ = try await apiClient.post(
+      url: endpoint,
+      dictionary: body,
+      token: token
+    )
+  }
+}
+
+fileprivate func buildPupilDaysOfWeekUrlComponent(pupilId: UUID) -> URLComponents {
+  let path = "/pupils/\(pupilId)/days-of-week"
+
+  return buildUrlComponent(path)
+}

--- a/Sources/ChildrensVillageApiClient/Requests/createPupilTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/createPupilTask.swift
@@ -12,7 +12,7 @@ func createPupilTask(
   apiClient: JsonApiCompatible = JsonApiClient(),
   _ token: String,
   _ pupil: NewPupilRequestModel
-) async throws -> PupilModel {
+) async throws -> UUID {
   let endpoint = buildPupilsUrlComponent().url!
 
   var body: [String: Any] = [
@@ -35,7 +35,8 @@ func createPupilTask(
     body["activeUntil"] = activeUntil
   }
 
-  return try await apiClient.post(url: endpoint, dictionary: body, token: token)
+  let createdPupil: PupilModel = try await apiClient.post(url: endpoint, dictionary: body, token: token)
+  return createdPupil.id
 }
 
 fileprivate func buildPupilsUrlComponent() -> URLComponents {

--- a/Sources/ChildrensVillageApiClient/Requests/createPupilTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/createPupilTask.swift
@@ -1,0 +1,45 @@
+//
+//  createPupilTask.swift
+//
+//
+//  Created on 25/06/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func createPupilTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ pupil: NewPupilRequestModel
+) async throws -> PupilModel {
+  let endpoint = buildPupilsUrlComponent().url!
+
+  var body: [String: Any] = [
+    "prefix": pupil.prefix.rawValue,
+    "firstName": pupil.firstName,
+    "lastName": pupil.lastName,
+    "active": pupil.active,
+    "photographyConsent": pupil.photographyConsent
+  ]
+
+  if let dateOfBirth = pupil.dateOfBirth {
+    body["dateOfBirth"] = dateOfBirth
+  }
+
+  if let allergies = pupil.allergies {
+    body["allergies"] = allergies
+  }
+
+  if let activeUntil = pupil.activeUntil {
+    body["activeUntil"] = activeUntil
+  }
+
+  return try await apiClient.post(url: endpoint, dictionary: body, token: token)
+}
+
+fileprivate func buildPupilsUrlComponent() -> URLComponents {
+  let path = "/pupils"
+
+  return buildUrlComponent(path)
+}

--- a/Sources/ChildrensVillageApiClient/Requests/createPupilWithAssociationsTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/createPupilWithAssociationsTask.swift
@@ -1,0 +1,31 @@
+//
+//  createPupilWithAssociationsTask.swift
+//  ChildrensVillageApiClient
+//
+//  Created by Chris Kobrzak on 18/11/2025.
+//
+
+
+import Foundation
+import JwtApiClient
+
+func createPupilWithAssociationsTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ pupil: NewPupilRequestModel,
+  _ parentIds: [UUID],
+  _ branchIds: [Int],
+  _ dayIds: [Int]
+) async throws -> UUID {
+  let pupilId = try await createPupilTask(apiClient: apiClient, token, pupil)
+
+  async let parentsRelationTask: Void = updatePupilParentsTask(apiClient: apiClient, token, pupilId, parentIds)
+  async let branchesRelationTask: Void = createPupilBranchesTask(apiClient: apiClient, token, pupilId, branchIds)
+  async let daysRelationTask: Void = createPupilDaysOfWeekTask(apiClient: apiClient, token, pupilId, dayIds)
+
+  _ = try await parentsRelationTask
+  _ = try await branchesRelationTask
+  _ = try await daysRelationTask
+
+  return pupilId
+}

--- a/Sources/ChildrensVillageApiClient/Requests/requestParentSummariesTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/requestParentSummariesTask.swift
@@ -1,0 +1,28 @@
+//
+//  requestParentSummariesTask.swift
+//
+//
+//  Created on 25/06/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func requestParentSummariesTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String
+) async throws -> [ParentModel] {
+  let urlFilter = buildParentSummariesRequestFilter()
+  let filterJson = JSONEncoder.encode(from: urlFilter)
+
+  let endpoint = buildParentsUrlComponent(filter: filterJson).url!
+
+  return try await apiClient.get(url: endpoint, token: token)
+}
+
+fileprivate func buildParentsUrlComponent(filter: String) -> URLComponents {
+  let path = "/parents"
+  let queryItem = URLQueryItem(name: "filter", value: filter)
+
+  return buildUrlComponent(path, queryItems: [queryItem])
+}

--- a/Sources/ChildrensVillageApiClient/Requests/requestParentTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/requestParentTask.swift
@@ -1,0 +1,30 @@
+//
+//  requestParentTask.swift
+//  ChildrensVillageApiClient
+//
+//  Created by Chris Kobrzak on 19/11/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func requestParentTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ parentId: UUID
+) async throws -> ParentModel {
+  let urlFilter = buildParentRequestFilter()
+  let filterJson = JSONEncoder.encode(from: urlFilter)
+
+  let endpoint = buildParentUrlComponent(parentId: parentId, filter: filterJson).url!
+
+  return try await apiClient.get(url: endpoint, token: token)
+}
+
+fileprivate func buildParentUrlComponent(parentId: UUID, filter: String) -> URLComponents {
+  let sanitisedParentId = parentId.uuidString.lowercased()
+  let path = "/parents/\(sanitisedParentId)"
+  let queryItem = URLQueryItem(name: "filter", value: filter)
+
+  return buildUrlComponent(path, queryItems: [queryItem])
+}

--- a/Sources/ChildrensVillageApiClient/Requests/requestPupilSummariesTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/requestPupilSummariesTask.swift
@@ -1,0 +1,28 @@
+//
+//  requestPupilSummariesTask.swift
+//
+//
+//  Created on 25/06/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func requestPupilSummariesTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String
+) async throws -> [PupilModel] {
+  let urlFilter = buildPupilSummariesRequestFilter()
+  let filterJson = JSONEncoder.encode(from: urlFilter)
+
+  let endpoint = buildPupilSummariesUrlComponent(filter: filterJson).url!
+
+  return try await apiClient.get(url: endpoint, token: token)
+}
+
+fileprivate func buildPupilSummariesUrlComponent(filter: String) -> URLComponents {
+  let path = "/pupils"
+  let queryItem = URLQueryItem(name: "filter", value: filter)
+
+  return buildUrlComponent(path, queryItems: [queryItem])
+}

--- a/Sources/ChildrensVillageApiClient/Requests/updateParentTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updateParentTask.swift
@@ -1,0 +1,58 @@
+//
+//  updateParentTask.swift
+//
+//
+//  Created on 2/11/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+fileprivate let serverErrorCode = 500
+
+func updateParentTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ parentId: UUID,
+  _ parent: UpdateParentRequestModel
+) async throws -> Int {
+  let endpoint = buildParentUrlComponent(parentId: parentId).url!
+
+  var body: [String: Any] = [:]
+
+  if let active = parent.active {
+    body["active"] = active
+  }
+  if let facilitating = parent.facilitating {
+    body["facilitating"] = facilitating
+  }
+  if let prefix = parent.prefix {
+    body["prefix"] = prefix.rawValue
+  }
+  if let firstName = parent.firstName {
+    body["firstName"] = firstName
+  }
+  if let lastName = parent.lastName {
+    body["lastName"] = lastName
+  }
+  if let phone = parent.phone {
+    body["phone"] = phone
+  }
+  if let email = parent.email {
+    body["email"] = email
+  }
+
+  let response: URLResponse = try await apiClient.patch(url: endpoint, dictionary: body)
+
+  guard let httpResponse = response as? HTTPURLResponse else {
+    return serverErrorCode
+  }
+
+  return httpResponse.statusCode
+}
+
+fileprivate func buildParentUrlComponent(parentId: UUID) -> URLComponents {
+  let path = "/parents/\(parentId)"
+
+  return buildUrlComponent(path)
+}

--- a/Sources/ChildrensVillageApiClient/Requests/updateParentTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updateParentTask.swift
@@ -42,12 +42,7 @@ func updateParentTask(
     body["email"] = email
   }
 
-  let response: URLResponse = try await apiClient.patch(url: endpoint, dictionary: body)
-
-  guard let httpResponse = response as? HTTPURLResponse,
-      200...299 ~= httpResponse.statusCode else {
-    throw URLError(.badServerResponse)
-  }
+  try await apiClient.patch(url: endpoint, dictionary: body, token: token)
 }
 
 fileprivate func buildParentUrlComponent(parentId: UUID) -> URLComponents {

--- a/Sources/ChildrensVillageApiClient/Requests/updateParentTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updateParentTask.swift
@@ -15,7 +15,7 @@ func updateParentTask(
   _ token: String,
   _ parentId: UUID,
   _ parent: UpdateParentRequestModel
-) async throws -> Int {
+) async throws {
   let endpoint = buildParentUrlComponent(parentId: parentId).url!
 
   var body: [String: Any] = [:]
@@ -44,11 +44,10 @@ func updateParentTask(
 
   let response: URLResponse = try await apiClient.patch(url: endpoint, dictionary: body)
 
-  guard let httpResponse = response as? HTTPURLResponse else {
-    return serverErrorCode
+  guard let httpResponse = response as? HTTPURLResponse,
+      200...299 ~= httpResponse.statusCode else {
+    throw URLError(.badServerResponse)
   }
-
-  return httpResponse.statusCode
 }
 
 fileprivate func buildParentUrlComponent(parentId: UUID) -> URLComponents {

--- a/Sources/ChildrensVillageApiClient/Requests/updatePupilBranchesTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updatePupilBranchesTask.swift
@@ -1,0 +1,33 @@
+//
+//  updatePupilBranchesTask.swift
+//
+//  Created on 18/11/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func updatePupilBranchesTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ pupilId: UUID,
+  _ branchIds: [Int]
+) async throws {
+  let endpoint = buildPupilBranchesUrlComponent(pupilId: pupilId).url!
+
+  let branches: [[String: Int]] = branchIds.map { branchId in
+    ["id": branchId]
+  }
+
+  let _ = try await apiClient.put(
+    url: endpoint,
+    dictionary: ["branches": branches],
+    token: token
+  )
+}
+
+fileprivate func buildPupilBranchesUrlComponent(pupilId: UUID) -> URLComponents {
+  let path = "/pupils/\(pupilId)/branches"
+
+  return buildUrlComponent(path)
+}

--- a/Sources/ChildrensVillageApiClient/Requests/updatePupilBranchesTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updatePupilBranchesTask.swift
@@ -15,13 +15,13 @@ func updatePupilBranchesTask(
 ) async throws {
   let endpoint = buildPupilBranchesUrlComponent(pupilId: pupilId).url!
 
-  let branches: [[String: Int]] = branchIds.map { branchId in
+  let branches = branchIds.map { branchId in
     ["id": branchId]
   }
 
-  let _ = try await apiClient.put(
+  try await apiClient.put(
     url: endpoint,
-    dictionary: ["branches": branches],
+    dictionaries: branches,
     token: token
   )
 }

--- a/Sources/ChildrensVillageApiClient/Requests/updatePupilDaysOfWeekTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updatePupilDaysOfWeekTask.swift
@@ -1,0 +1,29 @@
+//
+//  updatePupilDaysOfWeekTask.swift
+//
+//  Created on 18/11/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func updatePupilDaysOfWeekTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ pupilId: UUID,
+  _ dayIds: [Int]
+) async throws {
+  let endpoint = buildPupilDaysOfWeekUrlComponent(pupilId: pupilId).url!
+
+  let days: [[String: Int]] = dayIds.map { dayId in
+    ["id": dayId]
+  }
+
+  try await apiClient.put(url: endpoint, dictionary: ["days": days], token: token)
+}
+
+fileprivate func buildPupilDaysOfWeekUrlComponent(pupilId: UUID) -> URLComponents {
+  let path = "/pupils/\(pupilId)/days-of-week"
+
+  return buildUrlComponent(path)
+}

--- a/Sources/ChildrensVillageApiClient/Requests/updatePupilDaysOfWeekTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updatePupilDaysOfWeekTask.swift
@@ -15,11 +15,11 @@ func updatePupilDaysOfWeekTask(
 ) async throws {
   let endpoint = buildPupilDaysOfWeekUrlComponent(pupilId: pupilId).url!
 
-  let days: [[String: Int]] = dayIds.map { dayId in
+  let days = dayIds.map { dayId in
     ["id": dayId]
   }
 
-  try await apiClient.put(url: endpoint, dictionary: ["days": days], token: token)
+  try await apiClient.put(url: endpoint, dictionaries: days, token: token)
 }
 
 fileprivate func buildPupilDaysOfWeekUrlComponent(pupilId: UUID) -> URLComponents {

--- a/Sources/ChildrensVillageApiClient/Requests/updatePupilParentsTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updatePupilParentsTask.swift
@@ -1,0 +1,44 @@
+//
+//  updatePupilParents.swift
+//
+//  Created on 18/11/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func updatePupilParentsTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ pupilId: UUID,
+  _ parentIds: [UUID]
+) async throws {
+  let deleteEndpoint = buildDeleteParentsUrlComponent(pupilId: pupilId).url!
+  let createEndpoint = buildCreateParentAssociationUrlComponent(pupilId: pupilId).url!
+
+  try await apiClient.delete(url: deleteEndpoint, token: token)
+
+  for parentId in parentIds {
+    let body: [String: String] = [
+      "id": parentId.uuidString
+    ]
+
+    let _ = try await apiClient.post(
+      url: createEndpoint,
+      dictionary: body,
+      token: token
+    )
+  }
+}
+
+fileprivate func buildDeleteParentsUrlComponent(pupilId: UUID) -> URLComponents {
+  let path = "/pupils/\(pupilId)/parents"
+
+  return buildUrlComponent(path)
+}
+
+fileprivate func buildCreateParentAssociationUrlComponent(pupilId: UUID) -> URLComponents {
+  let path = "/pupils/\(pupilId)/parents"
+
+  return buildUrlComponent(path)
+}

--- a/Sources/ChildrensVillageApiClient/Requests/updatePupilTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updatePupilTask.swift
@@ -13,7 +13,7 @@ func updatePupilTask(
   _ token: String,
   _ pupilId: UUID,
   _ pupil: UpdatePupilRequestModel
-) async throws -> Int {
+) async throws {
   let endpoint = buildPupilUrlComponent(pupilId: pupilId).url!
 
   var body: [String: Any] = [:]
@@ -43,8 +43,7 @@ func updatePupilTask(
     body["allergies"] = allergies
   }
 
-  let _ = try await apiClient.patch(url: endpoint, dictionary: body, token: token)
-  return 1
+  try await apiClient.patch(url: endpoint, dictionary: body, token: token)
 }
 
 fileprivate func buildPupilUrlComponent(pupilId: UUID) -> URLComponents {

--- a/Sources/ChildrensVillageApiClient/Requests/updatePupilTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updatePupilTask.swift
@@ -1,0 +1,54 @@
+//
+//  updatePupilTask.swift
+//
+//
+//  Created on 2/11/2025.
+//
+
+import Foundation
+import JwtApiClient
+
+func updatePupilTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ pupilId: UUID,
+  _ pupil: UpdatePupilRequestModel
+) async throws -> Int {
+  let endpoint = buildPupilUrlComponent(pupilId: pupilId).url!
+
+  var body: [String: Any] = [:]
+
+  if let prefix = pupil.prefix {
+    body["prefix"] = prefix.rawValue
+  }
+  if let firstName = pupil.firstName {
+    body["firstName"] = firstName
+  }
+  if let lastName = pupil.lastName {
+    body["lastName"] = lastName
+  }
+  if let dateOfBirth = pupil.dateOfBirth {
+    body["dateOfBirth"] = dateOfBirth
+  }
+  if let active = pupil.active {
+    body["active"] = active
+  }
+  if let activeUntil = pupil.activeUntil {
+    body["activeUntil"] = activeUntil
+  }
+  if let photographyConsent = pupil.photographyConsent {
+    body["photographyConsent"] = photographyConsent
+  }
+  if let allergies = pupil.allergies {
+    body["allergies"] = allergies
+  }
+
+  let _ = try await apiClient.patch(url: endpoint, dictionary: body, token: token)
+  return 1
+}
+
+fileprivate func buildPupilUrlComponent(pupilId: UUID) -> URLComponents {
+  let path = "/pupils/\(pupilId)"
+
+  return buildUrlComponent(path)
+}

--- a/Sources/ChildrensVillageApiClient/Requests/updatePupilWithAssociationsTask.swift
+++ b/Sources/ChildrensVillageApiClient/Requests/updatePupilWithAssociationsTask.swift
@@ -1,0 +1,22 @@
+import Foundation
+import JwtApiClient
+
+func updatePupilWithAssociationsTask(
+  apiClient: JsonApiCompatible = JsonApiClient(),
+  _ token: String,
+  _ pupilId: UUID,
+  _ pupil: UpdatePupilRequestModel,
+  _ parentIds: [UUID],
+  _ branchIds: [Int],
+  _ dayIds: [Int]
+) async throws {
+  try await updatePupilTask(apiClient: apiClient, token, pupilId, pupil)
+
+  async let parentsUpdate: Void = updatePupilParentsTask(apiClient: apiClient, token, pupilId, parentIds)
+  async let branchesUpdate: Void = updatePupilBranchesTask(apiClient: apiClient, token, pupilId, branchIds)
+  async let daysUpdate: Void = updatePupilDaysOfWeekTask(apiClient: apiClient, token, pupilId, dayIds)
+
+  _ = try await parentsUpdate
+  _ = try await branchesUpdate
+  _ = try await daysUpdate
+}

--- a/Sources/ChildrensVillageApiClient/ResponseModels/BasePupilModel.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/BasePupilModel.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct BasePupilModel: Person, Decodable {
+  public let id: UUID
+  public let firstName: String
+  public let lastName: String
+  public let dateOfBirth: String?
+  public let prefix: TitlePrefix
+}

--- a/Sources/ChildrensVillageApiClient/ResponseModels/ErrorResponseHandlers/ParentModel+errorHandler.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/ErrorResponseHandlers/ParentModel+errorHandler.swift
@@ -19,8 +19,7 @@ extension ParentModel {
         let id = try? container.decode(UUID.self, forKey: .id),
         let firstName = try? container.decode(String.self, forKey: .firstName),
         let lastName = try? container.decode(String.self, forKey: .lastName),
-        let prefix = try? container.decode(TitlePrefix.self, forKey: .prefix),
-        let phone = try? container.decode(String.self, forKey: .phone)
+        let prefix = try? container.decode(TitlePrefix.self, forKey: .prefix)
     else {
       throw try ErrorModel(from: decoder).error
     }
@@ -30,6 +29,7 @@ extension ParentModel {
     let primary = try container.decodeIfPresent(Bool.self, forKey: .primary)
     let facilitating = try container.decodeIfPresent(Bool.self, forKey: .facilitating)
     let email = try container.decodeIfPresent(String.self, forKey: .email)
+    let phone = try container.decodeIfPresent(String.self, forKey: .phone) ?? ""
     let attendances = try container.decodeIfPresent([AttendanceModel].self, forKey: .attendances)
 
     self.init(

--- a/Sources/ChildrensVillageApiClient/ResponseModels/ErrorResponseHandlers/PupilModel+errorHandler.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/ErrorResponseHandlers/PupilModel+errorHandler.swift
@@ -14,6 +14,7 @@ extension PupilModel {
     case lastName
     case dateOfBirth
     case prefix
+    case active
     case activeUntil
     case photographyConsent
     case allergies
@@ -33,6 +34,7 @@ extension PupilModel {
     }
 
     let dateOfBirth = try container.decodeIfPresent(String.self, forKey: .dateOfBirth)
+    let active = try container.decodeIfPresent(Bool.self, forKey: .active)
     let activeUntil = try container.decodeIfPresent(String.self, forKey: .activeUntil)
     let photographyConsent = try container.decodeIfPresent(Bool.self, forKey: .photographyConsent)
     let allergies = try container.decodeIfPresent(String.self, forKey: .allergies)
@@ -47,6 +49,7 @@ extension PupilModel {
       lastName: lastName,
       dateOfBirth: dateOfBirth,
       prefix: prefix,
+      active: active,
       activeUntil: activeUntil,
       photographyConsent: photographyConsent,
       allergies: allergies,

--- a/Sources/ChildrensVillageApiClient/ResponseModels/ParentModel.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/ParentModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ParentModel: Attending, Identifiable, Decodable, Sendable {
+public struct ParentModel: Person, Attending, Decodable, Sendable {
   public let id: UUID
   public let active: Bool?
   public let facilitating: Bool?

--- a/Sources/ChildrensVillageApiClient/ResponseModels/ParentSummaryModel.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/ParentSummaryModel.swift
@@ -1,0 +1,16 @@
+//
+//  ParentSummaryModel.swift
+//  ChildrensVillageApiClient
+//
+//  Created on 25/06/2025.
+//
+
+import Foundation
+
+public struct ParentSummaryModel: Codable, Equatable {
+  public let prefix: TitlePrefix
+  public let firstName: String
+  public let lastName: String
+  public let active: Bool
+  public let facilitating: Bool
+}

--- a/Sources/ChildrensVillageApiClient/ResponseModels/Protocols/Attending.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/Protocols/Attending.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public protocol Attending: Sendable {
+public protocol Attending: Person, Sendable {
   var id: UUID  { get }
   var prefix: TitlePrefix { get }
   var firstName: String { get }

--- a/Sources/ChildrensVillageApiClient/ResponseModels/Protocols/Person.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/Protocols/Person.swift
@@ -1,0 +1,15 @@
+//
+//  Person.swift
+//  ChildrensVillageApiClient
+//
+//  Created by Chris Kobrzak on 25/06/2025.
+//
+
+import Foundation
+
+public protocol Person: Identifiable, Sendable {
+  var id: UUID { get }
+  var prefix: TitlePrefix { get }
+  var firstName: String { get }
+  var lastName: String { get }
+}

--- a/Sources/ChildrensVillageApiClient/ResponseModels/PupilModel.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/PupilModel.swift
@@ -1,11 +1,12 @@
 import Foundation
 
-public struct PupilModel: Attending, Identifiable, Decodable, Sendable {
+public struct PupilModel: Person, Attending, Decodable, Sendable {
   public let id: UUID
   public let firstName: String
   public let lastName: String
   public let dateOfBirth: String?
   public let prefix: TitlePrefix
+  public let active: Bool?
   public let activeUntil: String?
   public let photographyConsent: Bool?
   public let allergies: String?

--- a/Sources/ChildrensVillageApiClient/ResponseModels/PupilSummaryModel.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/PupilSummaryModel.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public struct PupilSummaryModel: Person, Decodable {
+  public let id: UUID
+  public let firstName: String
+  public let lastName: String
+  public let dateOfBirth: String?
+  public let prefix: TitlePrefix
+
+  // Additional properties
+  public let active: Bool
+}

--- a/Sources/ChildrensVillageApiClient/ResponseModels/TitlePrefix.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/TitlePrefix.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum TitlePrefix: String, Decodable, Sendable {
+public enum TitlePrefix: String, Codable, Sendable {
   case Ms
   case Master
   case Miss

--- a/Sources/ChildrensVillageApiClient/ResponseModels/TitlePrefix.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/TitlePrefix.swift
@@ -8,3 +8,14 @@ public enum TitlePrefix: String, Codable, Sendable, CaseIterable {
   case Mr
   case Mx
 }
+
+// MARK: - Category extensions
+public extension TitlePrefix {
+  static var childCases: [TitlePrefix] {
+    [.Miss, .Master, .Mx]
+  }
+
+  static var adultCases: [TitlePrefix] {
+    [.Ms, .Mrs, .Mr, .Mx]
+  }
+}

--- a/Sources/ChildrensVillageApiClient/ResponseModels/TitlePrefix.swift
+++ b/Sources/ChildrensVillageApiClient/ResponseModels/TitlePrefix.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum TitlePrefix: String, Codable, Sendable {
+public enum TitlePrefix: String, Codable, Sendable, CaseIterable {
   case Ms
   case Master
   case Miss

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -409,7 +409,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       .willReturn(urlResponse)
 
     // Act
-    let statusCode: Int = try await updatePupilTask(apiClient: client, token, pupilId, updatePupil)
+    try await updatePupilTask(apiClient: client, token, pupilId, updatePupil)
 
     // Assert
     verify(
@@ -438,8 +438,6 @@ class ChildrensVillageApiClientTests: XCTestCase {
       )
     )
       .wasCalled(exactly(1))
-
-    XCTAssertEqual(statusCode, acceptedStatusCode)
   }
 
   func testUpdatePupilTask_partialUpdate() async throws {
@@ -465,7 +463,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       .willReturn(urlResponse)
 
     // Act
-    let statusCode: Int = try await updatePupilTask(apiClient: client, token, pupilId, updatePupil)
+    try await updatePupilTask(apiClient: client, token, pupilId, updatePupil)
 
     // Assert
     verify(
@@ -485,8 +483,6 @@ class ChildrensVillageApiClientTests: XCTestCase {
       )
     )
       .wasCalled(exactly(1))
-
-    XCTAssertEqual(statusCode, acceptedStatusCode)
   }
 
   func testRequestAllPupilsRegisterTask() async throws {

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -169,7 +169,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       .willReturn(apiResponse)
 
     // Act
-    let result: ParentModel = try await createParentTask(apiClient: client, token, newParent)
+    let result: UUID = try await createParentTask(apiClient: client, token, newParent)
 
     // Assert
     let expectedUrl = URL(string: "\(baseApiUrl)/parents")
@@ -184,7 +184,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       .returning(ParentModel.self)
       .wasCalled(exactly(1))
 
-    XCTAssertEqual(result.id, apiResponse.id)
+    XCTAssertEqual(result, apiResponse.id)
   }
 
   func testCreatePupilTask() async throws {

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -227,7 +227,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       .willReturn(apiResponse)
 
     // Act
-    let result: PupilModel = try await createPupilTask(apiClient: client, token, newPupil)
+    let result: UUID = try await createPupilTask(apiClient: client, token, newPupil)
 
     // Assert
     let expectedUrl = URL(string: "\(baseApiUrl)/pupils")
@@ -242,9 +242,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       .returning(PupilModel.self)
       .wasCalled(exactly(1))
 
-    XCTAssertEqual(result.id, apiResponse.id)
-    XCTAssertEqual(result.firstName, apiResponse.firstName)
-    XCTAssertEqual(result.lastName, apiResponse.lastName)
+    XCTAssertEqual(result, apiResponse.id)
   }
 
   // FIXME: Mockingbird is complaining about the client.post mock

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -281,6 +281,108 @@ class ChildrensVillageApiClientTests: XCTestCase {
 //    }
 //  }
 
+  func testUpdateParentTask() async throws {
+    // Arrange
+    let token = "fake-update-token"
+    let parentId = UUID(uuidString: "753dfb2b-e6c7-4d35-9e6c-0665394b3e6a")!
+    let updateParent = UpdateParentRequestModel(
+      prefix: TitlePrefix.Mr,
+      firstName: "John",
+      lastName: "Doe",
+      active: true,
+      facilitating: true,
+      phone: "07700900456",
+      email: "john.doe@example.com"
+    )
+
+    let expectedUrl = URL(string: "\(baseApiUrl)/parents/\(parentId)")
+    let acceptedStatusCode = 204
+    let urlResponse: URLResponse = HTTPURLResponse(url: expectedUrl!, statusCode: acceptedStatusCode, httpVersion: "1.1", headerFields: nil)!
+
+    given(
+      await client.patch(
+        url: any(URL.self),
+        dictionary: any(keys: "active", "facilitating", "prefix", "firstName", "lastName", "phone", "email")
+      )
+    )
+      .willReturn(urlResponse)
+
+    // Act
+    let statusCode: Int = try await updateParentTask(apiClient: client, token, parentId, updateParent)
+
+    // Assert
+    verify(
+      await client.patch(
+        url: expectedUrl!,
+        dictionary: any(where: { dict in
+          // Compare the dictionaries - all fields should be present since we provided all values
+          guard let active = dict["active"] as? Bool,
+                let facilitating = dict["facilitating"] as? Bool,
+                let prefix = dict["prefix"] as? String,
+                let firstName = dict["firstName"] as? String,
+                let lastName = dict["lastName"] as? String,
+                let phone = dict["phone"] as? String,
+                let email = dict["email"] as? String else { return false }
+
+          return active == updateParent.active! &&
+                 facilitating == updateParent.facilitating! &&
+                 prefix == updateParent.prefix!.rawValue &&
+                 firstName == updateParent.firstName! &&
+                 lastName == updateParent.lastName! &&
+                 phone == updateParent.phone! &&
+                 email == updateParent.email!
+        })
+      )
+    )
+      .wasCalled(exactly(1))
+
+    XCTAssertEqual(statusCode, acceptedStatusCode)
+  }
+
+  func testUpdateParentTask_partialUpdate() async throws {
+    // Arrange
+    let token = "fake-update-token"
+    let parentId = UUID(uuidString: "753dfb2b-e6c7-4d35-9e6c-0665394b3e6a")!
+    let updateParent = UpdateParentRequestModel(
+      firstName: "Jane",
+      active: false
+    )
+
+    let expectedUrl = URL(string: "\(baseApiUrl)/parents/\(parentId)")
+    let acceptedStatusCode = 204
+    let urlResponse: URLResponse = HTTPURLResponse(url: expectedUrl!, statusCode: acceptedStatusCode, httpVersion: "1.1", headerFields: nil)!
+
+    given(
+      await client.patch(
+        url: any(URL.self),
+        dictionary: any(keys: "firstName", "active")
+      )
+    )
+      .willReturn(urlResponse)
+
+    // Act
+    let statusCode: Int = try await updateParentTask(apiClient: client, token, parentId, updateParent)
+
+    // Assert
+    verify(
+      await client.patch(
+        url: expectedUrl!,
+        dictionary: any(where: { dict in
+          // Only firstName and active should be present
+          guard dict.count == 2,
+                let active = dict["active"] as? Bool,
+                let firstName = dict["firstName"] as? String else { return false }
+
+          return active == updateParent.active! &&
+                 firstName == updateParent.firstName!
+        })
+      )
+    )
+      .wasCalled(exactly(1))
+
+    XCTAssertEqual(statusCode, acceptedStatusCode)
+  }
+
   func testRequestAllPupilsRegisterTask() async throws {
     // Arrange
     let token = "fake-register-token"

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -422,6 +422,67 @@ func testRequestPupilSummariesTask() async throws {
     XCTAssertEqual(result.last?.firstName, "Amy")
   }
 
+  func testRequestParentSummariesTask() async throws {
+    // Arrange
+    let token = "fake-parents-token"
+
+    let parentA = ParentModel(
+      id: UUID(uuidString: "753dfb2b-e6c7-4d35-9e6c-0665394b3e6a")!,
+      active: true,
+      facilitating: true,
+      primary: true,
+      firstName: "Jane",
+      lastName: "Doe",
+      prefix: TitlePrefix.Mrs,
+      phone: "07012345678",
+      email: "",
+      attendances: nil
+    )
+
+    let parentB = ParentModel(
+      id: UUID(uuidString: "753dfb2b-e6c7-4d35-9e6c-0665394b3e6a")!,
+      active: true,
+      facilitating: false,
+      primary: true,
+      firstName: "John",
+      lastName: "Smith",
+      prefix: TitlePrefix.Mr,
+      phone: "07987654321",
+      email: "",
+      attendances: nil
+    )
+
+    let apiResponse = [parentA, parentB]
+
+    given(
+      await client.get(
+        url: any(URL.self),
+        token: any(String.self)
+      )
+    )
+      .willReturn(apiResponse)
+
+    // Act
+    let result: [ParentModel] = try await requestParentSummariesTask(apiClient: client, token)
+
+    // Assert
+    verify(
+      await client.get(
+        url: any(URL.self, where: {
+          $0.description.contains("/api/parents") &&
+          $0.description.contains("filter=")
+        }),
+        token: token
+      )
+    )
+    .returning([ParentModel].self)
+    .wasCalled(exactly(1))
+
+    XCTAssertEqual(result.count, 2)
+    XCTAssertEqual(result.first?.firstName, "Jane")
+    XCTAssertEqual(result.last?.facilitating, false)
+  }
+
   func testRequestPupilTask() async throws {
     // Arrange
     let token = "fake-register-token"

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -132,6 +132,122 @@ class ChildrensVillageApiClientTests: XCTestCase {
     XCTAssertEqual(statusCode, acceptedStatusCode)
   }
 
+<<<<<<< HEAD
+=======
+func testCreateParentTask() async throws {
+    // Arrange
+    let token = "fake-token"
+    let newParent = NewParentRequestModel(
+      prefix: TitlePrefix.Mrs,
+      firstName: "Jane",
+      lastName: "Doe",
+      active: true,
+      facilitating: false,
+      phone: "07700900123",
+      email: "jane.doe@example.com",
+      primary: nil
+    )
+
+    let apiResponse = ParentModel(
+      id: UUID(uuidString: "753dfb2b-e6c7-4d35-9e6c-0665394b3e6a")!,
+      active: true,
+      facilitating: false,
+      primary: true,
+      firstName: "Jane",
+      lastName: "Doe",
+      prefix: TitlePrefix.Mrs,
+      phone: "07700900123",
+      email: "jane.doe@example.com",
+      attendances: nil
+    )
+
+    given(
+      await client.post(
+        url: any(URL.self),
+        dictionary: any(keys: "active", "facilitating", "prefix", "firstName", "lastName", "phone", "email"),
+        token: any(String.self)
+      )
+    )
+      .willReturn(apiResponse)
+
+    // Act
+    let result: UUID = try await createParentTask(apiClient: client, token, newParent)
+
+    // Assert
+    let expectedUrl = URL(string: "\(baseApiUrl)/parents")
+
+    verify(
+      await client.post(
+        url: expectedUrl!,
+        dictionary: any([String: Any].self),
+        token: token
+      )
+    )
+      .returning(ParentModel.self)
+      .wasCalled(exactly(1))
+
+    XCTAssertEqual(result, apiResponse.id)
+  }
+
+  func testCreatePupilTask() async throws {
+    // Arrange
+    let token = "fake-token"
+    let newPupil = NewPupilRequestModel(
+      prefix: TitlePrefix.Master,
+      firstName: "John",
+      lastName: "Smith",
+      dateOfBirth: "2015-03-20",
+      active: true,
+      activeUntil: nil,
+      photographyConsent: true,
+      allergies: "None"
+    )
+
+    let apiResponse = PupilModel(
+      id: UUID(uuidString: "123e4567-e89b-12d3-a456-426614174000")!,
+      firstName: "John",
+      lastName: "Smith",
+      dateOfBirth: "2015-03-20",
+      prefix: TitlePrefix.Master,
+      active: true,
+      activeUntil: nil,
+      photographyConsent: true,
+      allergies: "None",
+      parents: nil,
+      attendances: nil,
+      branches: nil,
+      daysOfWeek: nil
+    )
+
+    given(
+      await client.post(
+        url: any(URL.self),
+        dictionary: any(keys: "prefix", "firstName", "lastName", "dateOfBirth", "active", "photographyConsent", "allergies"),
+        token: any(String.self)
+      )
+    )
+      .willReturn(apiResponse)
+
+    // Act
+    let result: UUID = try await createPupilTask(apiClient: client, token, newPupil)
+
+    // Assert
+    let expectedUrl = URL(string: "\(baseApiUrl)/pupils")
+
+    verify(
+      await client.post(
+        url: expectedUrl!,
+        dictionary: any([String: Any].self),
+        token: token
+      )
+    )
+      .returning(PupilModel.self)
+      .wasCalled(exactly(1))
+
+    XCTAssertEqual(result, apiResponse.id)
+  }
+
+>>>>>>> 4cc4d72 (fixup! Add task for requesting list of pupils)
   // FIXME: Mockingbird is complaining about the client.post mock
 //  func testRequestTokenTask_withRequestError() async throws {
 //    // Arrange
@@ -184,6 +300,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       lastName: "Bloggs",
       dateOfBirth: "2015-01-01",
       prefix: TitlePrefix.Miss,
+      active: false,
       activeUntil: "2023-12-15",
       photographyConsent: true,
       allergies: "gluten free",
@@ -235,6 +352,76 @@ class ChildrensVillageApiClientTests: XCTestCase {
     XCTAssertEqual(result.first?.id, apiResponse.daysOfWeek?.first?.pupils?.first?.id)
   }
 
+func testRequestPupilSummariesTask() async throws {
+    // Arrange
+    let token = "fake-pupils-token"
+
+    let pupilA = PupilModel(
+      id: UUID(uuidString: "753dfb2b-e6c7-4d35-9e6c-0665394b3e6a")!,
+      firstName: "Joe",
+      lastName: "Bloggs",
+      dateOfBirth: "2015-01-01",
+      prefix: TitlePrefix.Master,
+      active: true,
+      activeUntil: nil,
+      photographyConsent: nil,
+      allergies: nil,
+      parents: nil,
+      attendances: nil,
+      branches: nil,
+      daysOfWeek: nil,
+      // FIXME: This field must be returned
+//      active: true
+    )
+
+    let pupilB = PupilModel(
+      id: UUID(uuidString: "0FB40D04-AC2F-4BAD-8E74-07BF2A4DD55D")!,
+      firstName: "Amy",
+      lastName: "Smith",
+      dateOfBirth: "2017-10-10",
+      prefix: TitlePrefix.Miss,
+      active: true,
+      activeUntil: nil,
+      photographyConsent: nil,
+      allergies: "Peanuts",
+      parents: nil,
+      attendances: nil,
+      branches: nil,
+      daysOfWeek: nil,
+//      active: false
+    )
+
+    let apiResponse = [pupilA, pupilB]
+
+    given(
+      await client.get(
+        url: any(URL.self),
+        token: any(String.self)
+      )
+    )
+      .willReturn(apiResponse)
+
+    // Act
+    let result: [PupilModel] = try await requestPupilSummariesTask(apiClient: client, token)
+
+    // Assert
+    verify(
+      await client.get(
+        url: any(URL.self, where: {
+          $0.description.contains("/api/pupils") &&
+          $0.description.contains("filter=")
+        }),
+        token: token
+      )
+    )
+    .returning([PupilModel].self)
+    .wasCalled(exactly(1))
+
+    XCTAssertEqual(result.count, 2)
+    XCTAssertEqual(result.first?.id, apiResponse.first?.id)
+    XCTAssertEqual(result.last?.firstName, "Amy")
+  }
+
   func testRequestPupilTask() async throws {
     // Arrange
     let token = "fake-register-token"
@@ -247,6 +434,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       lastName: "Bloggs",
       dateOfBirth: "2015-01-01",
       prefix: TitlePrefix.Miss,
+      active: true,
       activeUntil: "2023-12-15",
       photographyConsent: true,
       allergies: "",
@@ -399,6 +587,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       lastName: "Bloggs",
       dateOfBirth: "2015-01-01",
       prefix: TitlePrefix.Master,
+      active: false,
       activeUntil: "2023-12-13",
       photographyConsent: true,
       allergies: "gluten free",
@@ -413,6 +602,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       lastName: "Smith",
       dateOfBirth: "2017-10-10",
       prefix: TitlePrefix.Miss,
+      active: true,
       activeUntil: "",
       photographyConsent: false,
       allergies: "vegan",
@@ -427,6 +617,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       lastName: "Green",
       dateOfBirth: "2013-12-12",
       prefix: TitlePrefix.Master,
+      active: false,
       activeUntil: "2024-05-20",
       photographyConsent: false,
       allergies: nil,

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -11,10 +11,10 @@ import Mockingbird
 @testable import ChildrensVillageApiClient
 
 class ChildrensVillageApiClientTests: XCTestCase {
-  
+
   var client: JsonApiClientMock!
   var baseApiUrl = "https://childrens-village.co.uk/api"
-  
+
   override func setUp() {
     client = mock(JsonApiClient.self).initialize()
   }
@@ -132,9 +132,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
     XCTAssertEqual(statusCode, acceptedStatusCode)
   }
 
-<<<<<<< HEAD
-=======
-func testCreateParentTask() async throws {
+  func testCreateParentTask() async throws {
     // Arrange
     let token = "fake-token"
     let newParent = NewParentRequestModel(
@@ -171,7 +169,7 @@ func testCreateParentTask() async throws {
       .willReturn(apiResponse)
 
     // Act
-    let result: UUID = try await createParentTask(apiClient: client, token, newParent)
+    let result: ParentModel = try await createParentTask(apiClient: client, token, newParent)
 
     // Assert
     let expectedUrl = URL(string: "\(baseApiUrl)/parents")
@@ -186,7 +184,7 @@ func testCreateParentTask() async throws {
       .returning(ParentModel.self)
       .wasCalled(exactly(1))
 
-    XCTAssertEqual(result, apiResponse.id)
+    XCTAssertEqual(result.id, apiResponse.id)
   }
 
   func testCreatePupilTask() async throws {
@@ -229,7 +227,7 @@ func testCreateParentTask() async throws {
       .willReturn(apiResponse)
 
     // Act
-    let result: UUID = try await createPupilTask(apiClient: client, token, newPupil)
+    let result: PupilModel = try await createPupilTask(apiClient: client, token, newPupil)
 
     // Assert
     let expectedUrl = URL(string: "\(baseApiUrl)/pupils")
@@ -244,10 +242,11 @@ func testCreateParentTask() async throws {
       .returning(PupilModel.self)
       .wasCalled(exactly(1))
 
-    XCTAssertEqual(result, apiResponse.id)
+    XCTAssertEqual(result.id, apiResponse.id)
+    XCTAssertEqual(result.firstName, apiResponse.firstName)
+    XCTAssertEqual(result.lastName, apiResponse.lastName)
   }
 
->>>>>>> 4cc4d72 (fixup! Add task for requesting list of pupils)
   // FIXME: Mockingbird is complaining about the client.post mock
 //  func testRequestTokenTask_withRequestError() async throws {
 //    // Arrange

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -329,7 +329,8 @@ class ChildrensVillageApiClientTests: XCTestCase {
                  lastName == updateParent.lastName! &&
                  phone == updateParent.phone! &&
                  email == updateParent.email!
-        })
+        }),
+        token: token
       )
     )
       .wasCalled(exactly(1))
@@ -371,7 +372,8 @@ class ChildrensVillageApiClientTests: XCTestCase {
 
           return active == updateParent.active! &&
                  firstName == updateParent.firstName!
-        })
+        }),
+        token: token
       )
     )
       .wasCalled(exactly(1))
@@ -430,7 +432,8 @@ class ChildrensVillageApiClientTests: XCTestCase {
                  activeUntil == updatePupil.activeUntil! &&
                  photographyConsent == updatePupil.photographyConsent! &&
                  allergies == updatePupil.allergies!
-        })
+        }),
+        token: token
       )
     )
       .wasCalled(exactly(1))
@@ -475,7 +478,8 @@ class ChildrensVillageApiClientTests: XCTestCase {
           return firstName == updatePupil.firstName! &&
                  active == updatePupil.active! &&
                  photographyConsent == updatePupil.photographyConsent!
-        })
+        }),
+        token: token
       )
     )
       .wasCalled(exactly(1))

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -381,6 +381,114 @@ class ChildrensVillageApiClientTests: XCTestCase {
     XCTAssertEqual(statusCode, acceptedStatusCode)
   }
 
+  func testUpdatePupilTask() async throws {
+    // Arrange
+    let token = "fake-update-token"
+    let pupilId = UUID(uuidString: "123e4567-e89b-12d3-a456-426614174000")!
+    let updatePupil = UpdatePupilRequestModel(
+      prefix: TitlePrefix.Master,
+      firstName: "Johnny",
+      lastName: "Smith",
+      dateOfBirth: "2015-03-20",
+      active: true,
+      activeUntil: "2025-12-31",
+      photographyConsent: false,
+      allergies: "Peanuts"
+    )
+
+    let expectedUrl = URL(string: "\(baseApiUrl)/pupils/\(pupilId)")
+    let acceptedStatusCode = 204
+    let urlResponse: URLResponse = HTTPURLResponse(url: expectedUrl!, statusCode: acceptedStatusCode, httpVersion: "1.1", headerFields: nil)!
+
+    given(
+      await client.patch(
+        url: any(URL.self),
+        dictionary: any(keys: "prefix", "firstName", "lastName", "dateOfBirth", "active", "activeUntil", "photographyConsent", "allergies")
+      )
+    )
+      .willReturn(urlResponse)
+
+    // Act
+    let statusCode: Int = try await updatePupilTask(apiClient: client, token, pupilId, updatePupil)
+
+    // Assert
+    verify(
+      await client.patch(
+        url: expectedUrl!,
+        dictionary: any(where: { dict in
+          // Compare the dictionaries - all fields should be present since we provided all values
+          guard let prefix = dict["prefix"] as? String,
+                let firstName = dict["firstName"] as? String,
+                let lastName = dict["lastName"] as? String,
+                let dateOfBirth = dict["dateOfBirth"] as? String,
+                let active = dict["active"] as? Bool,
+                let activeUntil = dict["activeUntil"] as? String,
+                let photographyConsent = dict["photographyConsent"] as? Bool,
+                let allergies = dict["allergies"] as? String else { return false }
+
+          return prefix == updatePupil.prefix!.rawValue &&
+                 firstName == updatePupil.firstName! &&
+                 lastName == updatePupil.lastName! &&
+                 dateOfBirth == updatePupil.dateOfBirth! &&
+                 active == updatePupil.active! &&
+                 activeUntil == updatePupil.activeUntil! &&
+                 photographyConsent == updatePupil.photographyConsent! &&
+                 allergies == updatePupil.allergies!
+        })
+      )
+    )
+      .wasCalled(exactly(1))
+
+    XCTAssertEqual(statusCode, acceptedStatusCode)
+  }
+
+  func testUpdatePupilTask_partialUpdate() async throws {
+    // Arrange
+    let token = "fake-update-token"
+    let pupilId = UUID(uuidString: "123e4567-e89b-12d3-a456-426614174000")!
+    let updatePupil = UpdatePupilRequestModel(
+      firstName: "Johnny",
+      active: false,
+      photographyConsent: true
+    )
+
+    let expectedUrl = URL(string: "\(baseApiUrl)/pupils/\(pupilId)")
+    let acceptedStatusCode = 204
+    let urlResponse: URLResponse = HTTPURLResponse(url: expectedUrl!, statusCode: acceptedStatusCode, httpVersion: "1.1", headerFields: nil)!
+
+    given(
+      await client.patch(
+        url: any(URL.self),
+        dictionary: any(keys: "firstName", "active", "photographyConsent")
+      )
+    )
+      .willReturn(urlResponse)
+
+    // Act
+    let statusCode: Int = try await updatePupilTask(apiClient: client, token, pupilId, updatePupil)
+
+    // Assert
+    verify(
+      await client.patch(
+        url: expectedUrl!,
+        dictionary: any(where: { dict in
+          // Only firstName, active, and photographyConsent should be present
+          guard dict.count == 3,
+                let firstName = dict["firstName"] as? String,
+                let active = dict["active"] as? Bool,
+                let photographyConsent = dict["photographyConsent"] as? Bool else { return false }
+
+          return firstName == updatePupil.firstName! &&
+                 active == updatePupil.active! &&
+                 photographyConsent == updatePupil.photographyConsent!
+        })
+      )
+    )
+      .wasCalled(exactly(1))
+
+    XCTAssertEqual(statusCode, acceptedStatusCode)
+  }
+
   func testRequestAllPupilsRegisterTask() async throws {
     // Arrange
     let token = "fake-register-token"

--- a/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
+++ b/Tests/ChildrensVillageApiClientTests/ChildrensVillageApiClientTests.swift
@@ -306,7 +306,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       .willReturn(urlResponse)
 
     // Act
-    let statusCode: Int = try await updateParentTask(apiClient: client, token, parentId, updateParent)
+    _ = try await updateParentTask(apiClient: client, token, parentId, updateParent)
 
     // Assert
     verify(
@@ -333,8 +333,6 @@ class ChildrensVillageApiClientTests: XCTestCase {
       )
     )
       .wasCalled(exactly(1))
-
-    XCTAssertEqual(statusCode, acceptedStatusCode)
   }
 
   func testUpdateParentTask_partialUpdate() async throws {
@@ -359,7 +357,7 @@ class ChildrensVillageApiClientTests: XCTestCase {
       .willReturn(urlResponse)
 
     // Act
-    let statusCode: Int = try await updateParentTask(apiClient: client, token, parentId, updateParent)
+    _ = try await updateParentTask(apiClient: client, token, parentId, updateParent)
 
     // Assert
     verify(
@@ -377,8 +375,6 @@ class ChildrensVillageApiClientTests: XCTestCase {
       )
     )
       .wasCalled(exactly(1))
-
-    XCTAssertEqual(statusCode, acceptedStatusCode)
   }
 
   func testUpdatePupilTask() async throws {


### PR DESCRIPTION
Methods added to the interface:

- createParent
- requestParent
- requestParentSummaries
- updateParent
- createPupilWithAssociations (convenience wrapper)
- createPupil
- requestPupilSummaries
- updatePupilWithAssociations (convenience wrapper)
- updatePupil
- updatePupilParents
- updatePupilBranches
- updatePupilDaysOfWeek
